### PR TITLE
Add read-only STEP deserializer plug-in

### DIFF
--- a/IfcPlugins/plugin/plugin.xml
+++ b/IfcPlugins/plugin/plugin.xml
@@ -31,4 +31,9 @@
 		<interfaceClass>org.bimserver.plugins.modelcompare.ModelComparePlugin</interfaceClass>
 		<implementationClass>org.bimserver.ifc.compare.GuidBasedModelComparePlugin</implementationClass>
 	</PluginImplementation>
+
+    <PluginImplementation>
+        <interfaceClass>org.bimserver.plugins.deserializers.DeserializerPlugin</interfaceClass>
+        <implementationClass>org.bimserver.ifc.step.deserializer.readonly.IfcStepReadOnlyDeserializerPlugin</implementationClass>
+    </PluginImplementation>
 </PluginDescriptor>

--- a/IfcPlugins/src/org/bimserver/ifc/step/deserializer/readonly/ByteBuffer.java
+++ b/IfcPlugins/src/org/bimserver/ifc/step/deserializer/readonly/ByteBuffer.java
@@ -1,0 +1,113 @@
+package org.bimserver.ifc.step.deserializer.readonly;
+
+class ByteBuffer {
+	private ByteBufferPage first = new ByteBufferPage(1 << 20);
+	private ByteBufferPage writePage = first;
+	private ByteBufferPage readPage = first;
+	private int writePageIndex = 0;
+	private int readPageIndex = 0;
+	private int length;
+
+	public void append(byte[] values, int offset, int length) {
+		int pageIndex = this.length >> 20;
+		ByteBufferPage page = writePage;
+		if (writePageIndex != pageIndex) {
+			int i = writePageIndex;
+			if (writePageIndex < pageIndex) {
+				page = first;
+				i = 0;
+			}
+			for (; i < pageIndex; i++) {
+				if (page.next == null) {
+					page.next = new ByteBufferPage(1 << 20);
+				}
+				page = page.next;
+			}
+			writePage = page;
+			writePageIndex = pageIndex;
+		}
+		int bytesCopied = 0;
+		while (true) {
+			int destinationLength = Math.min(
+					page.buffer.length - page.position, length - bytesCopied);
+			System.arraycopy(values, bytesCopied, page.buffer, page.position,
+					destinationLength);
+			page.position += destinationLength;
+			this.length += destinationLength;
+			bytesCopied += destinationLength;
+			if (bytesCopied < length) {
+				page.next = new ByteBufferPage(1 << 20);
+				page = page.next;
+				writePage = page;
+				writePageIndex++;
+				continue;
+			}
+			break;
+		}
+	}
+
+	public byte byteAt(int index) {
+		if (index >= length) {
+			throw new IndexOutOfBoundsException();
+		}
+		int pageIndex = index >> 20;
+		ByteBufferPage page = readPage;
+		if (readPageIndex != pageIndex) {
+			int i = readPageIndex;
+			if (pageIndex < readPageIndex) {
+				page = first;
+				i = 0;
+			}
+			for (; i < pageIndex; i++) {
+				page = page.next;
+			}
+			readPage = page;
+			readPageIndex = pageIndex;
+		}
+		return page.buffer[index & 0xFFFFF];
+	}
+
+	public int bytesAt(byte[] buffer, int offset, int length) {
+		if (offset >= this.length || offset + length > this.length) {
+			throw new IndexOutOfBoundsException();
+		}
+		int pageIndex = offset >> 20;
+		ByteBufferPage page = readPage;
+		if (readPageIndex != pageIndex) {
+			int i = readPageIndex;
+			if (pageIndex < readPageIndex) {
+				page = first;
+				i = 0;
+			}
+			for (; i < pageIndex; i++) {
+				page = page.next;
+			}
+			readPage = page;
+			readPageIndex = pageIndex;
+		}
+		int bytesCopied = 0;
+		int position = offset - (pageIndex * 1 << 20);
+		while (true) {
+			int sourceLength = Math.min(page.buffer.length - position, length
+					- bytesCopied);
+			System.arraycopy(page.buffer, position, buffer, bytesCopied,
+					sourceLength);
+			position += sourceLength;
+			bytesCopied += sourceLength;
+			if (bytesCopied < length) {
+				page = page.next;
+				pageIndex++;
+				readPage = page;
+				readPageIndex = pageIndex;
+				position = 0;
+				continue;
+			}
+			break;
+		}
+		return bytesCopied;
+	}
+
+	public int length() {
+		return length;
+	}
+}

--- a/IfcPlugins/src/org/bimserver/ifc/step/deserializer/readonly/ByteBufferPage.java
+++ b/IfcPlugins/src/org/bimserver/ifc/step/deserializer/readonly/ByteBufferPage.java
@@ -1,0 +1,11 @@
+package org.bimserver.ifc.step.deserializer.readonly;
+
+class ByteBufferPage {
+	byte[] buffer;
+	int position;
+	public ByteBufferPage next;
+
+	public ByteBufferPage(int length) {
+		buffer = new byte[length];
+	}
+}

--- a/IfcPlugins/src/org/bimserver/ifc/step/deserializer/readonly/IfcStepReadOnlyDeserializer.java
+++ b/IfcPlugins/src/org/bimserver/ifc/step/deserializer/readonly/IfcStepReadOnlyDeserializer.java
@@ -1,0 +1,93 @@
+package org.bimserver.ifc.step.deserializer.readonly;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Date;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import org.bimserver.emf.IfcModelInterface;
+import org.bimserver.plugins.deserializers.DeserializeException;
+import org.bimserver.plugins.deserializers.EmfDeserializer;
+import org.bimserver.plugins.schema.SchemaDefinition;
+import org.bimserver.utils.FakeClosingInputStream;
+
+public class IfcStepReadOnlyDeserializer extends EmfDeserializer {
+
+	private SchemaDefinition schema;
+	private IfcModelInterface model;
+
+	public void init(SchemaDefinition schema) {
+		this.schema = schema;
+	}
+
+	public IfcModelInterface read(InputStream in, String filename, long fileSize) throws DeserializeException {
+		if (filename != null && (filename.toUpperCase().endsWith(".ZIP") || filename.toUpperCase().endsWith(".IFCZIP"))) {
+			ZipInputStream zipInputStream = new ZipInputStream(in);
+			ZipEntry nextEntry;
+			try {
+				nextEntry = zipInputStream.getNextEntry();
+				if (nextEntry == null) {
+					throw new DeserializeException("Zip files must contain exactly one IFC-file, this zip-file looks empty");
+				}
+				if (nextEntry.getName().toUpperCase().endsWith(".IFC")) {
+					IfcModelInterface model = null;
+					FakeClosingInputStream fakeClosingInputStream = new FakeClosingInputStream(zipInputStream);
+					model = read(fakeClosingInputStream, fileSize);
+					if (model.size() == 0) {
+						throw new DeserializeException("Uploaded file does not seem to be a correct IFC file");
+					}
+					if (zipInputStream.getNextEntry() != null) {
+						zipInputStream.close();
+						throw new DeserializeException("Zip files may only contain one IFC-file, this zip-file contains more files");
+					} else {
+						zipInputStream.close();
+						return model;
+					}
+				} else {
+					throw new DeserializeException("Zip files must contain exactly one IFC-file, this zip-file seems to have one or more non-IFC files");
+				}
+			} catch (IOException e) {
+				throw new DeserializeException(e);
+			}
+		} else {
+			return read(in, fileSize);
+		}
+	}
+
+	public IfcModelInterface read(File sourceFile) throws DeserializeException {
+		if (schema == null) {
+			throw new DeserializeException("No schema");
+		}
+		try {
+			FileInputStream in = new FileInputStream(sourceFile);
+			model = read(in, sourceFile.length());
+			in.close();
+			model.getModelMetaData().setDate(new Date());
+			model.getModelMetaData().setName(sourceFile.getName());
+			return model;
+		} catch (FileNotFoundException e) {
+			throw new DeserializeException(e);
+		} catch (IOException e) {
+			throw new DeserializeException(e);
+		}
+	}
+
+	private IfcModelInterface read(InputStream inputStream, long fileSize) throws DeserializeException {
+		IfcModelInterface model;
+		try {
+			StepExchange exchange = new StepParser(inputStream).parse();
+			model = new StepModel(exchange, schema);
+		} catch (IOException e) {
+			throw new DeserializeException(e);
+		}
+		return model;
+	}
+
+	public IfcModelInterface getModel() {
+		return model;
+	}
+}

--- a/IfcPlugins/src/org/bimserver/ifc/step/deserializer/readonly/IfcStepReadOnlyDeserializerPlugin.java
+++ b/IfcPlugins/src/org/bimserver/ifc/step/deserializer/readonly/IfcStepReadOnlyDeserializerPlugin.java
@@ -1,0 +1,58 @@
+package org.bimserver.ifc.step.deserializer.readonly;
+
+import org.bimserver.models.store.ObjectDefinition;
+import org.bimserver.plugins.PluginConfiguration;
+import org.bimserver.plugins.PluginException;
+import org.bimserver.plugins.PluginManager;
+import org.bimserver.plugins.deserializers.Deserializer;
+import org.bimserver.plugins.deserializers.DeserializerPlugin;
+import org.bimserver.plugins.schema.SchemaException;
+
+public class IfcStepReadOnlyDeserializerPlugin implements DeserializerPlugin {
+
+	boolean initialized = false;
+
+	@Override
+	public Deserializer createDeserializer(
+			PluginConfiguration pluginConfiguration) {
+		return new IfcStepReadOnlyDeserializer();
+	}
+
+	@Override
+	public String getDescription() {
+		return "IfcStepReadOnlyDeserializer";
+	}
+
+	@Override
+	public String getVersion() {
+		return "1.0";
+	}
+
+	@Override
+	public void init(PluginManager pluginManager) throws SchemaException,
+			PluginException {
+		pluginManager.requireSchemaDefinition();
+		initialized = true;
+	}
+
+	@Override
+	public boolean canHandleExtension(String extension) {
+		return extension.equalsIgnoreCase("ifc")
+				|| extension.equalsIgnoreCase("ifczip");
+	}
+
+	@Override
+	public boolean isInitialized() {
+		return initialized;
+	}
+
+	@Override
+	public String getDefaultName() {
+		return "IfcStepReadOnlyDeserializer";
+	}
+
+	@Override
+	public ObjectDefinition getSettingsDefinition() {
+		return null;
+	}
+}

--- a/IfcPlugins/src/org/bimserver/ifc/step/deserializer/readonly/StepAttribute.java
+++ b/IfcPlugins/src/org/bimserver/ifc/step/deserializer/readonly/StepAttribute.java
@@ -1,0 +1,11 @@
+package org.bimserver.ifc.step.deserializer.readonly;
+
+interface StepAttribute {
+	Object getValue();
+	boolean isUnset();
+	boolean isRedeclared();
+	boolean isEnum();
+	boolean isList();
+	boolean isInstanceName();
+	boolean isInline();
+}

--- a/IfcPlugins/src/org/bimserver/ifc/step/deserializer/readonly/StepAttributeImpl.java
+++ b/IfcPlugins/src/org/bimserver/ifc/step/deserializer/readonly/StepAttributeImpl.java
@@ -1,0 +1,125 @@
+package org.bimserver.ifc.step.deserializer.readonly;
+
+class StepAttributeImpl implements StepAttribute {
+
+	private final ByteBuffer dataBuffer;
+	private final TokenBuffer tokenBuffer;
+	private final int index;
+
+	public StepAttributeImpl(ByteBuffer dataBuffer,
+			TokenBuffer tokenBuffer, int index) {
+		this.dataBuffer = dataBuffer;
+		this.tokenBuffer = tokenBuffer;
+		this.index = index;
+	}
+
+	public int tokenLength() {
+		return 1;
+	}
+
+	@Override
+	public Object getValue() {
+		long token = tokenBuffer.tokenAt(index);
+		int offset = StepTokenizer.tokenPosition(token);
+		int length = StepTokenizer.tokenLength(token);
+		switch (StepTokenizer.tokenType(token)) {
+		case StepTokenizer.TOKEN_INTEGER:
+		{
+			byte[] buffer = new byte[length];
+			dataBuffer.bytesAt(buffer, offset, length);
+			String str = new String(buffer);
+			try {
+				return Integer.valueOf(str);
+			} catch (NumberFormatException e) {
+			}
+			try {
+				return Long.valueOf(str);
+			} catch (NumberFormatException e) {
+			}
+			throw new RuntimeException("Invalid integer " + new String(buffer));
+		}
+		case StepTokenizer.TOKEN_REAL:
+		{
+			byte[] buffer = new byte[length];
+			dataBuffer.bytesAt(buffer, offset, length);
+			String str = new String(buffer);
+			try {
+				return Double.valueOf(str);
+			} catch (NumberFormatException e) {
+			}
+			throw new RuntimeException("Invalid real " + new String(buffer));
+		}
+		case StepTokenizer.TOKEN_INSTANCE_NAME:
+		{
+			byte[] buffer = new byte[length];
+			dataBuffer.bytesAt(buffer, offset, length);
+			String str = new String(buffer);
+			try {
+				return Long.valueOf(str);
+			} catch (NumberFormatException e) {
+			}
+			throw new RuntimeException("Invalid instance id " + new String(buffer));
+		}
+		case StepTokenizer.TOKEN_ENUM:
+		{
+			byte[] buffer = new byte[length];
+			dataBuffer.bytesAt(buffer, offset, length);
+			return new String(buffer);
+		}
+		case StepTokenizer.TOKEN_STRING:
+		{
+			byte[] buffer = new byte[length];
+			dataBuffer.bytesAt(buffer, offset, length);
+			return StepStringDecoder.decode(buffer);
+		}
+		case StepTokenizer.TOKEN_IDENTIFIER:
+			if (StepTokenizer.tokenType(tokenBuffer.tokenAt(index + 1)) == StepTokenizer.TOKEN_LPAREN) {
+				return new StepEntityInstanceImpl(dataBuffer, tokenBuffer, index);
+			} else {
+				throw new RuntimeException("Missing attribute list for inline instance");
+			}
+		case StepTokenizer.TOKEN_UNSET:
+		case StepTokenizer.TOKEN_REDECLARED:
+			return null;
+		default:
+			throw new RuntimeException("Unknown token");
+		}
+	}
+
+	@Override
+	public boolean isUnset() {
+		return StepTokenizer.tokenType(tokenBuffer.tokenAt(index)) == StepTokenizer.TOKEN_UNSET;
+	}
+
+	public void markAsUnset() {
+		long token = tokenBuffer.tokenAt(index);
+		tokenBuffer.set(index, StepTokenizer.token(StepTokenizer.tokenType(StepTokenizer.TOKEN_UNSET), StepTokenizer.tokenPosition(token), StepTokenizer.tokenLength(token)));
+	}
+
+	@Override
+	public boolean isRedeclared() {
+		return StepTokenizer.tokenType(tokenBuffer.tokenAt(index)) == StepTokenizer.TOKEN_REDECLARED;
+	}
+
+	@Override
+	public boolean isList() {
+		return false;
+	}
+
+	@Override
+	public boolean isInstanceName() {
+		return StepTokenizer.tokenType(tokenBuffer.tokenAt(index)) == StepTokenizer.TOKEN_INSTANCE_NAME;
+	}
+
+	@Override
+	public boolean isEnum() {
+		return StepTokenizer.tokenType(tokenBuffer.tokenAt(index)) == StepTokenizer.TOKEN_ENUM;
+	}
+
+	@Override
+	public boolean isInline() {
+		return StepTokenizer.tokenType(tokenBuffer.tokenAt(index)) == StepTokenizer.TOKEN_IDENTIFIER &&
+			StepTokenizer.tokenType(tokenBuffer.tokenAt(index + 1)) == StepTokenizer.TOKEN_LPAREN;
+	}
+
+}

--- a/IfcPlugins/src/org/bimserver/ifc/step/deserializer/readonly/StepAttributeIterator.java
+++ b/IfcPlugins/src/org/bimserver/ifc/step/deserializer/readonly/StepAttributeIterator.java
@@ -1,0 +1,64 @@
+package org.bimserver.ifc.step.deserializer.readonly;
+
+import java.util.Iterator;
+
+class StepAttributeIterator implements Iterator<StepAttribute> {
+
+	private ByteBuffer dataBuffer;
+	private TokenBuffer tokenBuffer;
+	private int index;
+
+	public StepAttributeIterator(ByteBuffer dataBuffer,
+			TokenBuffer tokenBuffer, int index) {
+		this.dataBuffer = dataBuffer;
+		this.tokenBuffer = tokenBuffer;
+		this.index = index + 1;
+	}
+
+	@Override
+	public boolean hasNext() {
+		int tokenType = StepTokenizer.tokenType(tokenBuffer.tokenAt(index));
+		return tokenType != StepTokenizer.TOKEN_RPAREN;
+	}
+
+	@Override
+	public StepAttribute next() {
+		long token = tokenBuffer.tokenAt(index);
+		StepAttribute attribute = null;
+		switch (StepTokenizer.tokenType(token)) {
+		case StepTokenizer.TOKEN_INTEGER:
+		case StepTokenizer.TOKEN_REAL:
+		case StepTokenizer.TOKEN_STRING:
+		case StepTokenizer.TOKEN_UNSET:
+		case StepTokenizer.TOKEN_REDECLARED:
+		case StepTokenizer.TOKEN_INSTANCE_NAME:
+		case StepTokenizer.TOKEN_ENUM:
+			attribute = new StepAttributeImpl(dataBuffer, tokenBuffer, index);
+			break;
+		case StepTokenizer.TOKEN_IDENTIFIER:
+			attribute = new StepAttributeImpl(dataBuffer, tokenBuffer, index);
+			if (StepTokenizer.tokenType(tokenBuffer.tokenAt(index + 1)) == StepTokenizer.TOKEN_LPAREN) {
+				int listLength = new StepAttributeListImpl(dataBuffer,
+						tokenBuffer, index + 1).tokenLength();
+				index += listLength;
+			}
+			break;
+		case StepTokenizer.TOKEN_LPAREN:
+			StepAttributeListImpl list = new StepAttributeListImpl(
+					dataBuffer, tokenBuffer, index);
+			index += list.tokenLength() - 1;
+			attribute = list;
+			break;
+		default:
+			throw new RuntimeException();
+		}
+		index++;
+		return attribute;
+	}
+
+	@Override
+	public void remove() {
+	}
+
+
+}

--- a/IfcPlugins/src/org/bimserver/ifc/step/deserializer/readonly/StepAttributeList.java
+++ b/IfcPlugins/src/org/bimserver/ifc/step/deserializer/readonly/StepAttributeList.java
@@ -1,0 +1,11 @@
+package org.bimserver.ifc.step.deserializer.readonly;
+
+interface StepAttributeList extends StepAttribute {
+
+	StepAttribute get(int index);
+
+	int length();
+
+	StepAttributeIterator getAttributeIterator();
+
+}

--- a/IfcPlugins/src/org/bimserver/ifc/step/deserializer/readonly/StepAttributeListImpl.java
+++ b/IfcPlugins/src/org/bimserver/ifc/step/deserializer/readonly/StepAttributeListImpl.java
@@ -1,0 +1,188 @@
+package org.bimserver.ifc.step.deserializer.readonly;
+
+import org.apache.commons.lang.builder.EqualsBuilder;
+
+class StepAttributeListImpl implements StepAttributeList {
+
+	private final ByteBuffer dataBuffer;
+	private final TokenBuffer tokenBuffer;
+	private final int index;
+
+	public StepAttributeListImpl(ByteBuffer dataBuffer,
+			TokenBuffer tokenBuffer, int index) {
+		this.dataBuffer = dataBuffer;
+		this.tokenBuffer = tokenBuffer;
+		this.index = index;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (!(obj instanceof StepAttributeListImpl))
+			return false;
+		if (obj == this)
+			return true;
+		StepAttributeListImpl other = (StepAttributeListImpl) obj;
+		return new EqualsBuilder().append(dataBuffer, other.dataBuffer)
+				.append(tokenBuffer, other.tokenBuffer)
+				.append(index, other.index).isEquals();
+	}
+
+	public int tokenLength() {
+		int length = 0;
+		int i = index;
+		long token = tokenBuffer.tokenAt(i++);
+		if (StepTokenizer.tokenType(token) != StepTokenizer.TOKEN_LPAREN) {
+			throw new RuntimeException("Invalid state");
+		}
+		length++;
+		token = tokenBuffer.tokenAt(i);
+		if (StepTokenizer.tokenType(token) == StepTokenizer.TOKEN_RPAREN) {
+			length++;
+			return length;
+		}
+		while (true) {
+			token = tokenBuffer.tokenAt(i++);
+			switch (StepTokenizer.tokenType(token)) {
+			case StepTokenizer.TOKEN_INTEGER:
+			case StepTokenizer.TOKEN_REAL:
+			case StepTokenizer.TOKEN_STRING:
+			case StepTokenizer.TOKEN_UNSET:
+			case StepTokenizer.TOKEN_REDECLARED:
+			case StepTokenizer.TOKEN_INSTANCE_NAME:
+			case StepTokenizer.TOKEN_ENUM:
+				length++;
+				break;
+			case StepTokenizer.TOKEN_IDENTIFIER:
+				length++;
+				if (StepTokenizer.tokenType(tokenBuffer.tokenAt(i)) == StepTokenizer.TOKEN_LPAREN) {
+					int listLength = new StepAttributeListImpl(dataBuffer,
+							tokenBuffer, i).tokenLength();
+					i += listLength;
+					length += listLength;
+				}
+				break;
+			case StepTokenizer.TOKEN_LPAREN:
+				int listLength = new StepAttributeListImpl(dataBuffer,
+						tokenBuffer, i - 1).tokenLength();
+				i += listLength - 1;
+				length += listLength;
+				break;
+			case StepTokenizer.TOKEN_RPAREN:
+				length++;
+				return length;
+			default:
+				throw new RuntimeException("Unkonwn token");
+			}
+		}
+	}
+
+	@Override
+	public StepAttribute get(int attributeIndex) {
+		int i = index;
+		long token = tokenBuffer.tokenAt(i++);
+		if (StepTokenizer.tokenType(token) != StepTokenizer.TOKEN_LPAREN) {
+			throw new RuntimeException("Invalid state");
+		}
+		token = tokenBuffer.tokenAt(i);
+		if (StepTokenizer.tokenType(token) == StepTokenizer.TOKEN_RPAREN) {
+			throw new IndexOutOfBoundsException();
+		}
+		int currentAttributeIndex = 0;
+		StepAttribute attribute = null;
+		while (true) {
+			token = tokenBuffer.tokenAt(i);
+			switch (StepTokenizer.tokenType(token)) {
+			case StepTokenizer.TOKEN_INTEGER:
+			case StepTokenizer.TOKEN_REAL:
+			case StepTokenizer.TOKEN_STRING:
+			case StepTokenizer.TOKEN_UNSET:
+			case StepTokenizer.TOKEN_REDECLARED:
+			case StepTokenizer.TOKEN_INSTANCE_NAME:
+			case StepTokenizer.TOKEN_ENUM:
+				attribute = new StepAttributeImpl(dataBuffer, tokenBuffer, i);
+				break;
+			case StepTokenizer.TOKEN_IDENTIFIER:
+				attribute = new StepAttributeImpl(dataBuffer, tokenBuffer, i);
+				if (StepTokenizer.tokenType(tokenBuffer.tokenAt(i + 1)) == StepTokenizer.TOKEN_LPAREN) {
+					int listLength = new StepAttributeListImpl(dataBuffer,
+							tokenBuffer, i + 1).tokenLength();
+					i += listLength;
+				}
+				break;
+			case StepTokenizer.TOKEN_LPAREN:
+				StepAttributeListImpl list = new StepAttributeListImpl(
+						dataBuffer, tokenBuffer, i);
+				i += list.tokenLength() - 1;
+				attribute = list;
+				break;
+			case StepTokenizer.TOKEN_RPAREN:
+				throw new IndexOutOfBoundsException();
+			default:
+				throw new RuntimeException("Unkown token");
+			}
+			if (currentAttributeIndex == attributeIndex) {
+				return attribute;
+			}
+			currentAttributeIndex++;
+		}
+	}
+
+	@Override
+	public StepAttributeIterator getAttributeIterator() {
+		return new StepAttributeIterator(dataBuffer, tokenBuffer, index);
+	}
+
+	@Override
+	public int length() {
+		return rawLength() >> 1;
+	}
+
+	public int rawLength() {
+		long token = tokenBuffer.tokenAt(index);
+		if (StepTokenizer.tokenType(token) != StepTokenizer.TOKEN_LPAREN) {
+			throw new RuntimeException("Invalid state");
+		}
+		return StepTokenizer.tokenLength(token);
+	}
+
+	public void setRawLength(int length) {
+		long token = tokenBuffer.tokenAt(index);
+		tokenBuffer.set(index, StepTokenizer.token(StepTokenizer.tokenType(token), StepTokenizer.tokenPosition(token), length));
+	}
+
+	@Override
+	public Object getValue() {
+		return null;
+	}
+
+	@Override
+	public boolean isUnset() {
+		return false;
+	}
+
+	@Override
+	public boolean isRedeclared() {
+		return false;
+	}
+
+	@Override
+	public boolean isList() {
+		return true;
+	}
+
+	@Override
+	public boolean isInstanceName() {
+		return false;
+	}
+
+	@Override
+	public boolean isEnum() {
+		return false;
+	}
+
+	@Override
+	public boolean isInline() {
+		return false;
+	}
+
+}

--- a/IfcPlugins/src/org/bimserver/ifc/step/deserializer/readonly/StepEStore.java
+++ b/IfcPlugins/src/org/bimserver/ifc/step/deserializer/readonly/StepEStore.java
@@ -1,0 +1,894 @@
+package org.bimserver.ifc.step.deserializer.readonly;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import org.bimserver.emf.IdEObject;
+import org.bimserver.emf.IdEObjectImpl;
+import org.bimserver.interfaces.objects.SIfcHeader;
+import org.bimserver.models.ifc2x3tc1.Ifc2x3tc1Factory;
+import org.bimserver.models.ifc2x3tc1.Ifc2x3tc1Package;
+import org.bimserver.models.ifc2x3tc1.IfcBoolean;
+import org.bimserver.models.ifc2x3tc1.IfcLogical;
+import org.bimserver.models.ifc2x3tc1.Tristate;
+import org.bimserver.models.log.LogPackage;
+import org.bimserver.models.store.StorePackage;
+import org.bimserver.plugins.schema.Attribute;
+import org.bimserver.plugins.schema.EntityDefinition;
+import org.bimserver.plugins.schema.ExplicitAttribute;
+import org.bimserver.plugins.schema.InverseAttribute;
+import org.bimserver.plugins.schema.SchemaDefinition;
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EClassifier;
+import org.eclipse.emf.ecore.EEnumLiteral;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EPackage;
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.emf.ecore.EcorePackage;
+import org.eclipse.emf.ecore.InternalEObject;
+import org.eclipse.emf.ecore.InternalEObject.EStore;
+import org.eclipse.emf.ecore.impl.EEnumImpl;
+
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+
+class StepEStore implements EStore {
+	private final StepExchange exchange;
+	private final SchemaDefinition schema;
+
+	private class Inverse {
+		public long oid;
+		public String attributeName;
+		public Inverse(long oid, String attributeName) {
+			this.oid = oid;
+			this.attributeName = attributeName;
+		}
+	}
+
+	private final Map<Long, Integer> instances = Maps.newHashMap();
+	private Map<EClass, List<Integer>> instancesPerClass;
+	private Map<Long, List<Inverse>> instanceReferences;
+
+	private final Set<EStructuralFeature> inverseCache = Sets.newHashSet();
+	private final Map<EStructuralFeature, Integer> attributeIndexCache = Maps.newHashMap();
+
+	private final Map<IdEObject, Integer> inlineInstances = Maps.newHashMap();
+	private static final Map<String, EClassifier> eClasses = initEClasses();
+	private static final Map<EClass, List<EClass>> eClassSubTypes = initEClassSubTypes();
+	private static final BiMap<EClass, Class<?>> eClassClassMap = initEClassClassMap();
+
+	private Object attributeIteratorContainer;
+	private StepAttributeIterator attributeIterator;
+	private int attributeIndex = -1;
+	private StepAttribute attribute;
+
+	private Object attributeListIteratorContainer;
+	private StepAttributeIterator attributeListIterator;
+	private int attributeListIndex = -1;
+	private SIfcHeader ifcHeader;
+
+	public StepEStore(StepExchange exchange, SchemaDefinition schema) {
+		this.exchange = exchange;
+		this.schema = schema;
+		this.buildIfcHeader();
+		this.buildIndex();
+	}
+
+	private void buildIfcHeader() {
+		ifcHeader = new SIfcHeader();
+		StepEntityInstanceIterator it = exchange.getHeaderEntityIterator();
+		while (it.hasNext()) {
+			StepEntityInstance instance = it.next();
+			String identifier = instance.getIdentifier();
+			if (identifier.equals("FILE_DESCRIPTION")) {
+				/*
+				ENTITY file_description;
+				  description          : LIST [1:?] OF STRING (256) ;
+				  implementation_level : STRING (256) ;
+				END_ENTITY;
+				*/
+				StepAttributeIterator attributeIt = instance.getAttributeIterator();
+
+				StepAttributeList description = (StepAttributeList) attributeIt.next();
+				StepAttributeIterator descriptionIt = description.getAttributeIterator();
+				while (descriptionIt.hasNext()) {
+					ifcHeader.getDescription().add((String) descriptionIt.next().getValue());
+				}
+
+				StepAttribute implementationLevel = attributeIt.next();
+				ifcHeader.setImplementationLevel((String) implementationLevel.getValue());
+
+			} else if (identifier.equals("FILE_NAME")) {
+				/*
+				ENTITY file_name;
+				  name                 : STRING (256) ;
+				  time_stamp           : time_stamp_text ;
+				  author               : LIST [ 1 : ? ] OF STRING (256) ;
+				  organization         : LIST [ 1 : ? ] OF STRING (256) ;
+				  preprocessor_version : STRING (256) ;
+				  originating_system   : STRING (256) ;
+				  authorization        : STRING (256) ;
+				END_ENTITY;
+				*/
+				StepAttributeIterator attributeIt = instance.getAttributeIterator();
+
+				StepAttribute name = attributeIt.next();
+				ifcHeader.setFilename((String) name.getValue());
+
+				StepAttribute timeStamp = attributeIt.next();
+				try {
+					SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'kk:mm:ss");
+					ifcHeader.setTimeStamp(dateFormat.parse((String) timeStamp.getValue()));
+				} catch (ParseException e) {
+					throw new RuntimeException("Invalid time_stamp format", e);
+				}
+
+				StepAttributeList author = (StepAttributeList) attributeIt.next();
+				StepAttributeIterator authorIt = author.getAttributeIterator();
+				while (authorIt.hasNext()) {
+					ifcHeader.getAuthor().add((String) authorIt.next().getValue());
+				}
+
+				StepAttributeList organization = (StepAttributeList) attributeIt.next();
+				StepAttributeIterator organizationIt = organization.getAttributeIterator();
+				while (organizationIt.hasNext()) {
+					ifcHeader.getOrganization().add((String) organizationIt.next().getValue());
+				}
+
+				StepAttribute preProcessorVersion = attributeIt.next();
+				ifcHeader.setPreProcessorVersion((String) preProcessorVersion.getValue());
+
+				StepAttribute originatingSystem = attributeIt.next();
+				ifcHeader.setOriginatingSystem((String) originatingSystem.getValue());
+
+				StepAttribute authorization = attributeIt.next();
+				ifcHeader.setAuthorization((String) authorization.getValue());
+			} else if (identifier.equals("FILE_SCHEMA")) {
+				/*
+				ENTITY file_schema;
+				  schema_identifiers : LIST [1:?] OF UNIQUE schema_name;
+				END_ENTITY;
+				*/
+				StepAttributeIterator attributeIt = instance.getAttributeIterator();
+
+				StepAttributeList schemaIdentifiers = (StepAttributeList) attributeIt.next();
+				StepAttributeIterator schemaIdentifiersIt = schemaIdentifiers.getAttributeIterator();
+				while (schemaIdentifiersIt.hasNext()) {
+					ifcHeader.setIfcSchemaVersion((String) schemaIdentifiersIt.next().getValue());
+					break;
+				}
+			} else {
+				throw new RuntimeException("Unkown header entity " + identifier);
+			}
+		}		
+	}
+
+	private void buildIndex() {
+		instancesPerClass = new HashMap<EClass, List<Integer>>();
+		for (EClass eClass : eClassClassMap.keySet()) {
+			instancesPerClass.put((EClass) eClass, new ArrayList<Integer>());
+		}
+
+		StepEntityInstanceIterator it = exchange.getDataEntityIterator();
+		while (it.hasNext()) {
+			StepEntityInstance instance = it.next();
+			instances.put(instance.getInstanceName(), instance.getIndex());
+			String identifier = instance.getIdentifier();
+			EClass eClass = (EClass) eClasses.get(identifier);
+			instancesPerClass.get(eClass).add(instance.getIndex());
+		}
+	}
+
+	class Relation {
+		public String sourceAttributeName;
+		public int sourceAttributeIndex;
+		public String targetAttributeName;
+	}
+	
+	private void buildReferences() {
+		instanceReferences = Maps.newHashMap();
+
+		Map<String, List<Relation>> relations = Maps.newHashMap();
+
+		{
+			Iterator<EntityDefinition> entityIterator = schema.getEntities().iterator();
+			while (entityIterator.hasNext()) {
+				EntityDefinition entity = (EntityDefinition) entityIterator.next();
+				relations.put(entity.getName().toUpperCase(), Lists.<Relation>newArrayList());
+			}
+		}
+
+		{
+			Iterator<EntityDefinition> entityIterator = schema.getEntities().iterator();
+			while (entityIterator.hasNext()) {
+				EntityDefinition entity = (EntityDefinition) entityIterator.next();
+				Iterator<Attribute> attributeIterator = entity.getAttributes(true).iterator();
+				while (attributeIterator.hasNext()) {
+					Attribute attribute = (Attribute) attributeIterator.next();
+					if (attribute instanceof InverseAttribute) {
+						InverseAttribute inverseAttribute = (InverseAttribute) attribute;
+						String sourceEntityName = (inverseAttribute).getDomain().getName();
+						String sourceAttributeName = inverseAttribute.getInverted_attr().getName();
+						Relation relation = new Relation();
+						relation.sourceAttributeName = sourceAttributeName;
+						relation.targetAttributeName = attribute.getName();
+						relations.get(sourceEntityName.toUpperCase()).add(relation);
+					}
+				}
+			}
+		}
+
+		for (Entry<String, List<Relation>> entry : relations.entrySet()) {
+			EntityDefinition entity = schema.getEntityBN(entry.getKey());
+			if (!entry.getValue().isEmpty()) {
+				int i = 0;
+				Iterator<Attribute> attributeIterator = entity.getAttributes(true).iterator();
+				while (attributeIterator.hasNext()) {
+					Attribute attribute = (Attribute) attributeIterator.next();
+					if (attribute instanceof ExplicitAttribute) {
+						for (Relation relation : entry.getValue()) {
+							if (relation.sourceAttributeName.equals(attribute.getName())) {
+								relation.sourceAttributeIndex = i;
+							}
+						}
+						i++;
+					}
+				}
+			}
+		}
+		for (Entry<String, List<Relation>> entry : relations.entrySet()) {
+			EClass classifier = (EClass) eClasses.get(entry.getKey());
+			addSuperRelations(entry.getValue(), relations, classifier);
+		}
+
+		for (Entry<String, List<Relation>> entry : relations.entrySet()) {
+			Collections.sort(entry.getValue(), new Comparator<Relation>() {
+				@Override
+				public int compare(Relation left, Relation right) {
+					return left.sourceAttributeIndex < right.sourceAttributeIndex ? -1
+							: left.sourceAttributeIndex == right.sourceAttributeIndex ? 0
+									: 1;
+				}
+			});
+		}
+
+		for (Entry<String, List<Relation>> entry : relations.entrySet()) {
+			List<Relation> list = entry.getValue();
+			if (list.isEmpty()) continue;
+			int index = list.get(0).sourceAttributeIndex;
+			for (int i = 1; i < list.size();) {
+				if (list.get(i).sourceAttributeIndex == index) {
+					list.remove(i);
+				} else {
+					index = list.get(i).sourceAttributeIndex;
+					i++;
+				}
+			}
+		}
+
+		StepEntityInstanceIterator it = exchange.getDataEntityIterator();
+		while (it.hasNext()) {
+			StepEntityInstance instance = it.next();
+			String identifier = instance.getIdentifier();
+
+			Iterator<StepAttribute> attributeIterator = instance.getAttributeIterator();
+			Iterator<Relation> relationIterator = relations.get(identifier).iterator();
+
+			int i = 0;
+			while (relationIterator.hasNext()) {
+				Relation relation = relationIterator.next();
+				while (attributeIterator.hasNext()) {
+					StepAttribute attribute = attributeIterator.next();
+					if (relation.sourceAttributeIndex == i) {
+						if (attribute.isInstanceName()) {
+							addReference(instance.getInstanceName(), attribute, relation.targetAttributeName);
+						} else if (attribute.isList()) {
+							addReferences(instance.getInstanceName(), (StepAttributeList) attribute, relation.targetAttributeName);
+						}
+						i++;
+						break;
+					} else {
+						i++;
+					}
+				}
+			}
+		}
+	}
+
+	private void addSuperRelations(List<Relation> result, Map<String, List<Relation>> relations, EClass classifier) {
+		for (EClass superClassifier : classifier.getESuperTypes()) {
+			if (relations.containsKey(superClassifier.getName().toUpperCase())) {
+				result.addAll(relations.get(superClassifier.getName().toUpperCase()));
+			}
+			addSuperRelations(result, relations, superClassifier);
+		}
+	}
+
+	private void addReferences(long instanceName, StepAttributeList attributes, String attributeName) {
+		StepAttributeIterator iterator = attributes.getAttributeIterator();
+		while (iterator.hasNext()) {
+			StepAttribute attribute = iterator.next();
+			if (attribute.isInstanceName()) {
+				addReference(instanceName, attribute, attributeName);
+			} else if (attribute.isList()) {
+				addReferences(instanceName, (StepAttributeList) attribute, attributeName);
+			}
+		}
+	}
+
+	private void addReference(long instanceName, StepAttribute attribute, String attributeName) {
+		Long referencedName = (Long) attribute.getValue();
+		if (!instanceReferences.containsKey(referencedName)) {
+			instanceReferences.put(referencedName, Lists.<Inverse>newArrayList());
+		}
+		instanceReferences.get(referencedName).add(new Inverse(instanceName, attributeName));
+	}
+
+	private static Map<String, EClassifier> initEClasses() {
+		HashMap<String, EClassifier> result = new HashMap<String, EClassifier>(Ifc2x3tc1Package.eINSTANCE.getEClassifiers().size());
+		for (EClassifier classifier : Ifc2x3tc1Package.eINSTANCE.getEClassifiers()) {
+			result.put(classifier.getName().toUpperCase(), classifier);
+		}
+		return result;
+	}
+
+	private static Map<EClass, List<EClass>> initEClassSubTypes() {
+		HashMap<EClass, List<EClass>> result = new HashMap<EClass, List<EClass>>(Ifc2x3tc1Package.eINSTANCE.getEClassifiers().size());
+		for (EClassifier classifier : Ifc2x3tc1Package.eINSTANCE.getEClassifiers()) {
+			if (classifier instanceof EClass) {
+				result.put((EClass) classifier, Lists.<EClass>newArrayList());
+			}
+		}
+		for (EClassifier classifier : Ifc2x3tc1Package.eINSTANCE.getEClassifiers()) {
+			if (classifier instanceof EClass) {
+				for (EClass superType : ((EClass) classifier).getESuperTypes()) {
+					result.get(superType).add((EClass) classifier);
+				}
+			}
+		}
+		return result;
+	}
+
+	private static BiMap<EClass, Class<?>> initEClassClassMap() {
+		BiMap<EClass, Class<?>> eClassClassMap = HashBiMap.create();
+		for (EPackage ePackage : new EPackage[] { Ifc2x3tc1Package.eINSTANCE, StorePackage.eINSTANCE, LogPackage.eINSTANCE }) {
+			for (EClassifier eClassifier : ePackage.getEClassifiers()) {
+				if (eClassifier instanceof EClass) {
+					EClass eClass = (EClass) eClassifier;
+					eClassClassMap.put(eClass, eClass.getInstanceClass());
+				}
+			}
+		}
+		return eClassClassMap;
+	}
+
+	@Override
+	public Object get(InternalEObject object, EStructuralFeature feature,
+			int index) {
+		StepAttribute attribute = getAttribute(object, feature);
+		if (attribute == null) {
+			if (isInverse(feature)) {
+				long oid = ((IdEObjectImpl) object).getOid();
+				if (instanceReferences == null) {
+					this.buildReferences();
+				}
+				if (instanceReferences.containsKey(oid)) {
+					int i = 0;
+					for (Inverse inverse : instanceReferences.get(oid)) {
+						if (inverse.attributeName.equals(feature.getName())) {
+							if (index == InternalEObject.EStore.NO_INDEX || i == index) {
+								return create(getInstanceIndex(inverse.oid));
+							}
+							i++;
+						}
+					}
+				}
+			}
+			return null;
+		}
+		if (attribute.isList()) {
+			if (index == InternalEObject.EStore.NO_INDEX) {
+				throw new RuntimeException();
+			}
+
+			if (!attribute.equals(attributeListIteratorContainer)) {
+				attributeListIteratorContainer = attribute;
+				attributeListIterator = ((StepAttributeList) attribute).getAttributeIterator();
+				attributeListIndex = -1;
+			}
+			EClassifier eType = feature.getEType();
+			if (index != this.attributeListIndex + 1) {
+				attributeListIndex = -1;
+				attributeListIterator = ((StepAttributeList) attribute)
+						.getAttributeIterator();
+			}
+			for (; attributeListIndex < index && attributeListIterator.hasNext();) {
+				attribute = attributeListIterator.next();
+				if (eType instanceof EClass && attribute.isUnset()) {
+					attribute = null;
+					continue;
+				} else {
+					attributeListIndex++;
+				}
+			}
+		}
+
+		if (attribute == null) {
+			return null;
+		}
+
+		if (attribute.isInstanceName()) {
+			Long instanceName = (Long) attribute.getValue();
+			return create(getInstanceIndex(instanceName));
+		} else if (attribute.isEnum()) {
+			return getEnum(feature, attribute.getValue());
+		} else if (attribute.isInline()) {
+			return create((StepEntityInstance) attribute.getValue());
+		} else if (attribute.isUnset()) {
+			return null;
+		} else if (attribute.isRedeclared()) {
+			return null;
+		} else if (attribute.isList()) {
+			return null;
+		} else {
+			Object value = attribute.getValue();
+			EClassifier eType = feature.getEType();
+			if (eType == EcorePackage.eINSTANCE.getEDouble()) {
+				if (value instanceof Integer) {
+					return new Double((Integer) value);
+				} else if (value instanceof Long) {
+					return new Double((Long) value);
+				}
+			}
+			return value;
+		}
+	}
+
+	private StepAttribute getAttribute(InternalEObject object,
+			EStructuralFeature feature) {
+		int attributeIndex = getAttributeIndex(object, feature);
+		if (attributeIndex == -1) {
+			return null;
+		}
+
+		if (attributeIteratorContainer == object) {
+			if (attributeIndex == this.attributeIndex) {
+				return attribute;
+			}
+			if (attributeIndex == this.attributeIndex + 1) {
+				if (attributeIterator.hasNext()) {
+					this.attributeIndex++;
+					attribute = attributeIterator.next();
+					return attribute;
+				} else {
+					return null;
+				}
+			}
+		}
+
+		long oid = ((IdEObjectImpl) object).getOid();
+		Integer instanceIndex = instances.get(oid);
+		if (instanceIndex == null) {
+			instanceIndex = inlineInstances.get(object);
+		}
+		if (instanceIndex == null) {
+			return null;
+		}
+
+		StepEntityInstance instance = exchange.getDataEntity(instanceIndex);
+		attributeIterator = instance.getAttributeIterator();
+		attributeIteratorContainer = object;
+		for (this.attributeIndex = 0; this.attributeIndex < attributeIndex && attributeIterator.hasNext(); this.attributeIndex++, attributeIterator.next());
+		attribute = attributeIterator.next();
+		return attribute;
+	}
+
+	private int getAttributeIndex(InternalEObject object,
+			EStructuralFeature feature) {
+		if (attributeIndexCache.containsKey(feature)) {
+			return attributeIndexCache.get(feature);
+		}
+		int index = 0;
+		for (EStructuralFeature current : object.eClass().getEAllStructuralFeatures()) {
+			if (current.isDerived() || current.getEAnnotation("hidden") != null || isInverse(current)) {
+				continue;
+			}
+			if (feature.equals(current)) {
+				attributeIndexCache.put(feature, index);
+				return index;
+			}
+			index++;
+		}
+		attributeIndexCache.put(feature, -1);
+		return -1;
+	}
+
+	private boolean isInverse(EStructuralFeature feature) {
+		if (inverseCache.contains(feature)) {
+			return true;
+		}
+		EntityDefinition entityBN = schema.getEntityBN(feature.getEContainingClass().getName());
+		if (entityBN == null) {
+			return false;
+		}
+		Attribute attributeBNWithSuper = entityBN.getAttributeBNWithSuper(feature.getName());
+		boolean isInverse = attributeBNWithSuper instanceof InverseAttribute;
+		if (isInverse) {
+			inverseCache.add(feature);
+		}
+		return isInverse;
+	}
+
+	private Object getEnum(EStructuralFeature feature,
+			Object value) {
+		Object result = null;
+		if (value.equals("T")) {
+			if (feature.getEType() == Ifc2x3tc1Package.eINSTANCE.getTristate()) {
+				result = Tristate.TRUE;
+			} else if (feature.getEType().getName().equals("IfcBoolean")) {
+				IfcBoolean bool = Ifc2x3tc1Factory.eINSTANCE.createIfcBoolean();
+				bool.setWrappedValue(Tristate.TRUE);
+				result = bool;
+			} else if (feature.getEType() == EcorePackage.eINSTANCE.getEBoolean()) {
+				result = true;
+			} else {
+				IfcLogical locical = Ifc2x3tc1Factory.eINSTANCE.createIfcLogical();
+				locical.setWrappedValue(Tristate.TRUE);
+				result = locical;
+			}
+		} else if (value.equals("F")) {
+			if (feature.getEType() == Ifc2x3tc1Package.eINSTANCE.getTristate()) {
+				result = Tristate.FALSE;
+			} else if (feature.getEType().getName().equals("IfcBoolean")) {
+				IfcBoolean bool = Ifc2x3tc1Factory.eINSTANCE.createIfcBoolean();
+				bool.setWrappedValue(Tristate.FALSE);
+				result = bool;
+			} else if (feature.getEType() == EcorePackage.eINSTANCE.getEBoolean()) {
+				result = false;
+			} else {
+				IfcLogical logical = Ifc2x3tc1Factory.eINSTANCE.createIfcLogical();
+				logical.setWrappedValue(Tristate.FALSE);
+				result = logical;
+			}
+		} else if (value.equals("U")) {
+			if (feature.getEType() == Ifc2x3tc1Package.eINSTANCE.getTristate()) {
+				result = Tristate.UNDEFINED;
+			} else if (feature.getEType() == EcorePackage.eINSTANCE.getEBoolean()) {
+				result = null;
+			} else {
+				IfcLogical logical = Ifc2x3tc1Factory.eINSTANCE.createIfcLogical();
+				logical.setWrappedValue(Tristate.UNDEFINED);
+				result = logical;
+			}
+		} else {
+			EEnumLiteral enumLiteral = (((EEnumImpl) feature.getEType()).getEEnumLiteral((String) value));
+			if (enumLiteral == null) {
+				if ("NOTDEFINED".equals(value)) {
+					result = null;
+				} else {
+					throw new RuntimeException();
+				}
+			} else {
+				result = enumLiteral.getInstance();
+			}
+		}
+		return result;
+	}
+
+	@Override
+	public Object set(InternalEObject object, EStructuralFeature feature,
+			int index, Object value) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean isSet(InternalEObject object, EStructuralFeature feature) {
+		StepAttribute attribute = getAttribute(object, feature);
+		if (attribute == null) {
+			if (isInverse(feature)) {
+				long oid = ((IdEObjectImpl) object).getOid();
+				if (instanceReferences == null) {
+					this.buildReferences();
+				}
+				if (instanceReferences.containsKey(oid)) {
+					for (Inverse inverse : instanceReferences.get(oid)) {
+						if (inverse.attributeName.equals(feature.getName())) {
+							return true;
+						}
+					}
+				}
+				return false;
+			}
+		}
+		return !(attribute.isRedeclared() || attribute.isUnset());
+	}
+
+	@Override
+	public void unset(InternalEObject object, EStructuralFeature feature) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean isEmpty(InternalEObject object, EStructuralFeature feature) {
+		StepAttribute attribute = getAttribute(object, feature);
+		if (attribute == null) {
+			return true;
+		}
+		if (attribute.isList()) {
+			return ((StepAttributeList) attribute).length() == 0;
+		}
+		return false;
+	}
+
+	@Override
+	public int size(InternalEObject object, EStructuralFeature feature) {
+		StepAttribute attribute = getAttribute(object, feature);
+		if (attribute == null) {
+			if (isInverse(feature)) {
+				int size = 0;
+				long oid = ((IdEObjectImpl) object).getOid();
+				if (instanceReferences == null) {
+					this.buildReferences();
+				}
+				if (instanceReferences.containsKey(oid)) {
+					for (Inverse inverse : instanceReferences.get(oid)) {
+						if (inverse.attributeName.equals(feature.getName())) {
+							size++;
+						}
+					}
+				}
+				return size;
+			}
+			return 0;
+		}
+		if (attribute.isList()) {
+			EClassifier eType = feature.getEType();
+			if (eType instanceof EClass) {
+				StepAttributeListImpl list = ((StepAttributeListImpl) attribute);
+				int size = list.rawLength();
+				if ((size & 1) == 1) {
+					return size >> 1;
+				}
+				size = 0;
+				StepAttributeIterator it = list.getAttributeIterator();
+				while (it.hasNext()) {
+					if (!skipListItem(it.next())) size++;
+				}
+				list.setRawLength((size << 1) | 1);
+				return size;
+			}
+			return ((StepAttributeList) attribute).length();
+		}
+		return 0;
+	}
+
+	private boolean skipListItem(StepAttribute attribute) {
+		if (attribute.isUnset()) {
+			return true;
+		} else if (attribute.isInstanceName()) {
+			Long instanceName = (Long) attribute.getValue();
+			if (!instances.containsKey(instanceName)) {
+				((StepAttributeImpl) attribute).markAsUnset();
+				return true;
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public boolean contains(InternalEObject object, EStructuralFeature feature,
+			Object value) {
+		StepAttribute attribute = getAttribute(object, feature);
+		if (attribute == null) {
+			if (isInverse(feature)) {
+				long oid = ((IdEObjectImpl) object).getOid();
+				if (instanceReferences == null) {
+					this.buildReferences();
+				}
+				if (instanceReferences.containsKey(oid)) {
+					for (Inverse inverse : instanceReferences.get(oid)) {
+						if (inverse.attributeName.equals(feature.getName())) {
+							if (inverse.oid == ((IdEObjectImpl) value).getOid()) {
+								return true;
+							}
+						}
+					}
+				}
+			}
+			return false;
+		}
+		return contains(attribute, value);
+	}
+
+	private boolean contains(StepAttribute attribute, Object value) {
+		if (attribute.isList()) {
+			return contains((StepAttributeList) attribute, value);
+		} else if (attribute.isInstanceName()) {
+			return attribute.getValue().equals(((IdEObjectImpl) value).getOid());
+		} else {
+			return attribute.getValue().equals(value);
+		}
+	}
+
+	private boolean contains(StepAttributeList attributeList, Object value) {
+		StepAttributeIterator iterator = attributeList.getAttributeIterator();
+		while (iterator.hasNext()) {
+			StepAttribute attribute = iterator.next();
+			return contains(attribute, value);
+		}
+		return false;
+	}
+
+	@Override
+	public int indexOf(InternalEObject object, EStructuralFeature feature,
+			Object value) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public int lastIndexOf(InternalEObject object, EStructuralFeature feature,
+			Object value) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void add(InternalEObject object, EStructuralFeature feature,
+			int index, Object value) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Object remove(InternalEObject object, EStructuralFeature feature,
+			int index) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Object move(InternalEObject object, EStructuralFeature feature,
+			int targetIndex, int sourceIndex) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void clear(InternalEObject object, EStructuralFeature feature) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Object[] toArray(InternalEObject object, EStructuralFeature feature) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public <T> T[] toArray(InternalEObject object, EStructuralFeature feature,
+			T[] array) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public int hashCode(InternalEObject object, EStructuralFeature feature) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public InternalEObject getContainer(InternalEObject object) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public EStructuralFeature getContainingFeature(InternalEObject object) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public EObject create(EClass eClass) {
+		IdEObject object = (IdEObject) Ifc2x3tc1Factory.eINSTANCE.create(eClass);
+		((IdEObjectImpl) object).eSetStore(this);
+		return object;
+	}
+
+	private IdEObject create(int instanceIndex) {
+		return create(exchange.getDataEntity(instanceIndex));
+	}
+
+	private IdEObject create(StepEntityInstance instance) {
+		String identifier = instance.getIdentifier();
+		EClass eClass = (EClass) eClasses.get(identifier);
+		if (eClass == null) {
+			throw new RuntimeException();
+		}
+		IdEObject object = (IdEObject) create(eClass);
+		long instanceName = instance.getInstanceName();
+		((IdEObjectImpl) object).setExpressId(instanceName);
+		((IdEObjectImpl) object).setOid(instanceName);
+		if (instanceName > 0) {
+			instances.put(instanceName, instance.getIndex());
+		} else {
+			inlineInstances.put(object, instance.getIndex());
+		}
+		return object;
+	}
+
+	public Iterator<IdEObject> iterator() {
+		return new Iterator<IdEObject>() {
+			private final StepEntityInstanceIterator it = exchange.getDataEntityIterator();
+
+			@Override
+			public void remove() {
+			}
+
+			@Override
+			public IdEObject next() {
+				return create(it.next());
+			}
+
+			@Override
+			public boolean hasNext() {
+				return it.hasNext();
+			}
+		};
+	}
+
+	public <T extends IdEObject> List<T> getAll(Class<T> clazz) {
+		return getAll(eClassClassMap.inverse().get(clazz));
+	}
+
+	@SuppressWarnings("unchecked")
+	public <T extends IdEObject> List<T> getAll(EClass eClass) {
+		List<Integer> list = instancesPerClass.get(eClass);
+		if (list == null) {
+			return Collections.emptyList();
+		}
+		List<T> result = Lists.newArrayList();
+		for (int instanceIndex : list) {
+			result.add((T) create(instanceIndex));
+		}
+		return result;
+	}
+
+	public <T extends IdEObject> List<T> getAllWithSubTypes(Class<T> clazz) {
+		return getAllWithSubTypes(eClassClassMap.inverse().get(clazz));
+	}
+
+	@SuppressWarnings("unchecked")
+	public <T extends IdEObject> List<T> getAllWithSubTypes(EClass eClass) {
+		List<T> result = Lists.newArrayList();
+		result.addAll((List<T>) getAll(eClass));
+		for (EClass subtype : eClassSubTypes.get(eClass)) {
+			result.addAll((List<T>) getAllWithSubTypes(subtype));
+		}
+		return result;
+	}
+
+	public boolean contains(IdEObject referencedObject) {
+		return instances.containsKey(((IdEObjectImpl) referencedObject).getOid());
+	}
+
+	public IdEObject get(long oid) {
+		return create(getInstanceIndex(oid));
+	}
+
+	private int getInstanceIndex(long instanceName) {
+		Integer instanceIndex = instances.get(instanceName);
+		if (instanceIndex == null) {
+			throw new RuntimeException(String.format("Instance #%d missing from exchange", instanceName));
+		}
+		return instanceIndex;
+	}
+
+	public SIfcHeader getIfcHeader() {
+		return ifcHeader;
+	}
+}

--- a/IfcPlugins/src/org/bimserver/ifc/step/deserializer/readonly/StepEntityInstance.java
+++ b/IfcPlugins/src/org/bimserver/ifc/step/deserializer/readonly/StepEntityInstance.java
@@ -1,0 +1,8 @@
+package org.bimserver.ifc.step.deserializer.readonly;
+
+interface StepEntityInstance {
+	int getIndex();
+	StepAttributeIterator getAttributeIterator();
+	long getInstanceName();
+	String getIdentifier();
+}

--- a/IfcPlugins/src/org/bimserver/ifc/step/deserializer/readonly/StepEntityInstanceImpl.java
+++ b/IfcPlugins/src/org/bimserver/ifc/step/deserializer/readonly/StepEntityInstanceImpl.java
@@ -1,0 +1,98 @@
+package org.bimserver.ifc.step.deserializer.readonly;
+
+class StepEntityInstanceImpl implements StepEntityInstance {
+
+	private final ByteBuffer dataBuffer;
+	private final TokenBuffer tokenBuffer;
+	private final int index;
+
+	public StepEntityInstanceImpl(ByteBuffer dataBuffer,
+			TokenBuffer tokenBuffer, int index) {
+		this.dataBuffer = dataBuffer;
+		this.tokenBuffer = tokenBuffer;
+		this.index = index;
+	}
+
+	@Override
+	public int getIndex() {
+		return index;
+	}
+
+	@Override
+	public StepAttributeIterator getAttributeIterator() {
+		int i = index;
+		long token = tokenBuffer.tokenAt(i++);
+		if (StepTokenizer.tokenType(token) == StepTokenizer.TOKEN_INSTANCE_NAME) {
+			token = tokenBuffer.tokenAt(i++);
+			if (StepTokenizer.tokenType(token) != StepTokenizer.TOKEN_EQUAL) {
+				throw new RuntimeException();
+			}
+			token = tokenBuffer.tokenAt(i++);
+		}
+		if (StepTokenizer.tokenType(token) != StepTokenizer.TOKEN_IDENTIFIER) {
+			throw new RuntimeException();
+		}
+		return new StepAttributeIterator(dataBuffer, tokenBuffer, i);
+	}
+
+	public int tokenLength() {
+		int length = 0;
+		int i = index;
+		long token = tokenBuffer.tokenAt(i++);
+		if (StepTokenizer.tokenType(token) == StepTokenizer.TOKEN_INSTANCE_NAME) {
+			length++;
+			token = tokenBuffer.tokenAt(i++);
+			if (StepTokenizer.tokenType(token) != StepTokenizer.TOKEN_EQUAL) {
+				throw new RuntimeException();
+			}
+			length++;
+			token = tokenBuffer.tokenAt(i++);
+		}
+		if (StepTokenizer.tokenType(token) != StepTokenizer.TOKEN_IDENTIFIER) {
+			throw new RuntimeException();
+		}
+		length++;
+
+		int listLength = new StepAttributeListImpl(dataBuffer, tokenBuffer, i).tokenLength();
+		i += listLength;
+		length += listLength;
+
+		return length;
+	}
+
+	@Override
+	public String getIdentifier() {
+		int i = index;
+		long token = tokenBuffer.tokenAt(i++);
+		if (StepTokenizer.tokenType(token) == StepTokenizer.TOKEN_INSTANCE_NAME) {
+			token = tokenBuffer.tokenAt(i++);
+			if (StepTokenizer.tokenType(token) != StepTokenizer.TOKEN_EQUAL) {
+				throw new RuntimeException();
+			}
+			token = tokenBuffer.tokenAt(i++);
+		}
+		if (StepTokenizer.tokenType(token) != StepTokenizer.TOKEN_IDENTIFIER) {
+			throw new RuntimeException();
+		}
+
+		int offset = StepTokenizer.tokenPosition(token);
+		int length = StepTokenizer.tokenLength(token);
+		byte[] buffer = new byte[length];
+		dataBuffer.bytesAt(buffer, offset, length);
+		return new String(buffer);
+	}
+
+	@Override
+	public long getInstanceName() {
+		long token = tokenBuffer.tokenAt(index);
+		if (StepTokenizer.tokenType(token) != StepTokenizer.TOKEN_INSTANCE_NAME) {
+			return -1;
+		}
+		int offset = StepTokenizer.tokenPosition(token);
+		int length = StepTokenizer.tokenLength(token);
+		byte[] buffer = new byte[length];
+		dataBuffer.bytesAt(buffer, offset, length);
+		return Long.parseLong(new String(buffer));
+	}
+
+}

--- a/IfcPlugins/src/org/bimserver/ifc/step/deserializer/readonly/StepEntityInstanceIterator.java
+++ b/IfcPlugins/src/org/bimserver/ifc/step/deserializer/readonly/StepEntityInstanceIterator.java
@@ -1,0 +1,34 @@
+package org.bimserver.ifc.step.deserializer.readonly;
+
+import java.util.Iterator;
+
+class StepEntityInstanceIterator implements Iterator<StepEntityInstance> {
+
+	private ByteBuffer dataBuffer;
+	private TokenBuffer tokenBuffer;
+	private int index;
+
+	public StepEntityInstanceIterator(ByteBuffer dataBuffer,
+			TokenBuffer tokenBuffer, int index) {
+		this.dataBuffer = dataBuffer;
+		this.tokenBuffer = tokenBuffer;
+		this.index = index;
+	}
+
+	@Override
+	public boolean hasNext() {
+		return StepTokenizer.tokenType(tokenBuffer.tokenAt(index)) != StepTokenizer.TOKEN_ENDSEC;
+	}
+
+	@Override
+	public StepEntityInstance next() {
+		StepEntityInstanceImpl instance = new StepEntityInstanceImpl(dataBuffer, tokenBuffer, index);
+		index += instance.tokenLength();
+		return instance;
+	}
+
+	@Override
+	public void remove() {
+	}
+
+}

--- a/IfcPlugins/src/org/bimserver/ifc/step/deserializer/readonly/StepExchange.java
+++ b/IfcPlugins/src/org/bimserver/ifc/step/deserializer/readonly/StepExchange.java
@@ -1,0 +1,7 @@
+package org.bimserver.ifc.step.deserializer.readonly;
+
+interface StepExchange {
+	StepEntityInstanceIterator getHeaderEntityIterator();
+	StepEntityInstanceIterator getDataEntityIterator();
+	StepEntityInstance getDataEntity(int index);
+}

--- a/IfcPlugins/src/org/bimserver/ifc/step/deserializer/readonly/StepExchangeImpl.java
+++ b/IfcPlugins/src/org/bimserver/ifc/step/deserializer/readonly/StepExchangeImpl.java
@@ -1,0 +1,31 @@
+package org.bimserver.ifc.step.deserializer.readonly;
+
+class StepExchangeImpl implements StepExchange {
+	private final ByteBuffer dataBuffer;
+	private final TokenBuffer tokenBuffer;
+	private final int headerIndex;
+	private final int dataIndex;
+
+	public StepExchangeImpl(ByteBuffer dataBuffer, TokenBuffer tokenBuffer,
+			int headerIndex, int dataIndex) {
+		this.dataBuffer = dataBuffer;
+		this.tokenBuffer = tokenBuffer;
+		this.headerIndex = headerIndex;
+		this.dataIndex = dataIndex;
+	}
+
+	@Override
+	public StepEntityInstanceIterator getHeaderEntityIterator() {
+		return new StepEntityInstanceIterator(dataBuffer, tokenBuffer, headerIndex);
+	}
+
+	@Override
+	public StepEntityInstanceIterator getDataEntityIterator() {
+		return new StepEntityInstanceIterator(dataBuffer, tokenBuffer, dataIndex);
+	}
+
+	@Override
+	public StepEntityInstance getDataEntity(int index) {
+		return new StepEntityInstanceImpl(dataBuffer, tokenBuffer, index);
+	}
+}

--- a/IfcPlugins/src/org/bimserver/ifc/step/deserializer/readonly/StepModel.java
+++ b/IfcPlugins/src/org/bimserver/ifc/step/deserializer/readonly/StepModel.java
@@ -1,0 +1,251 @@
+package org.bimserver.ifc.step.deserializer.readonly;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import org.bimserver.emf.IdEObject;
+import org.bimserver.emf.IfcModelInterface;
+import org.bimserver.emf.IfcModelInterfaceException;
+import org.bimserver.emf.ModelMetaData;
+import org.bimserver.emf.OidProvider;
+import org.bimserver.models.ifc2x3tc1.IfcRoot;
+import org.bimserver.plugins.schema.SchemaDefinition;
+import org.bimserver.shared.PublicInterfaceNotFoundException;
+import org.bimserver.shared.exceptions.ServerException;
+import org.bimserver.shared.exceptions.UserException;
+import org.eclipse.emf.ecore.EClass;
+
+import com.google.common.collect.BiMap;
+import com.google.common.collect.Lists;
+
+class StepModel implements IfcModelInterface {
+
+	private StepEStore eStore;
+	private final ModelMetaData modelMetaData = new ModelMetaData();
+
+	public StepModel(StepExchange exchange, SchemaDefinition schema) {
+		this.eStore = new StepEStore(exchange, schema);
+		this.modelMetaData.setIfcHeader(this.eStore.getIfcHeader());
+	}
+
+	@Override
+	public Iterator<IdEObject> iterator() {
+		return eStore.iterator();
+	}
+
+	@Override
+	public IfcRoot getByGuid(String guid) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public IdEObject getByName(EClass eClass, String name) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public IdEObject get(long oid) {
+		return eStore.get(oid);
+	}
+
+	@Override
+	public Set<String> getGuids(EClass eClass) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Set<String> getNames(EClass eClass) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public long size() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean containsGuid(String referredGuid) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean contains(long oid) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public int count(EClass eClass) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Collection<IdEObject> getValues() {
+		return Lists.newArrayList(iterator());
+	}
+
+	@Override
+	public BiMap<Long, IdEObject> getObjects() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Set<Long> keySet() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public <T extends IdEObject> List<T> getAll(Class<T> clazz) {
+		return eStore.getAll(clazz);
+	}
+
+	@Override
+	public <T extends IdEObject> List<T> getAll(EClass clazz) {
+		return eStore.getAll(clazz);
+	}
+
+	@Override
+	public <T extends IdEObject> List<T> getAllWithSubTypes(Class<T> clazz) {
+		return eStore.getAllWithSubTypes(clazz);
+	}
+
+	@Override
+	public <T extends IdEObject> List<T> getAllWithSubTypes(EClass eClass) {
+		return eStore.getAllWithSubTypes(eClass);
+	}
+
+	@Override
+	public boolean contains(IdEObject referencedObject) {
+		return eStore.contains(referencedObject);
+	}
+
+	@Override
+	public void add(long oid, IdEObject newObject)
+			throws IfcModelInterfaceException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void addAllowMultiModel(long oid, IdEObject newObject)
+			throws IfcModelInterfaceException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void remove(IdEObject objectToRemove) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public ModelMetaData getModelMetaData() {
+		return modelMetaData;
+	}
+
+	@Override
+	public <T extends IdEObject> T create(EClass eClass)
+			throws IfcModelInterfaceException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public <T extends IdEObject> T create(Class<T> clazz)
+			throws IfcModelInterfaceException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void fixOids(OidProvider<Long> oidProvider) {
+	}
+
+	@Override
+	public void setObjectOids() {
+	}
+
+	@Override
+	public void indexGuids() {
+	}
+
+	@Override
+	public long getHighestOid() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void resetOids() {
+	}
+
+	@Override
+	public void resetOidsFlat() {
+	}
+
+	@Override
+	public boolean isValid() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void checkDoubleOidsPlusReferences() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void fixOidCounter() {
+	}
+
+	@Override
+	public void setUseDoubleStrings(boolean useDoubleStrings) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean isUseDoubleStrings() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void changeOid(IdEObject object) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void fixOids() {
+	}
+
+	@Override
+	public void generateMinimalExpressIds() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Collection<IdEObject> getUnidentifiedValues() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public int countWithSubtypes(EClass eClass) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void clear() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void resetExpressIds() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public IfcModelInterface branch(long poid) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public long commit(String comment) throws ServerException, UserException,
+			PublicInterfaceNotFoundException {
+		throw new UnsupportedOperationException();
+	}
+
+}

--- a/IfcPlugins/src/org/bimserver/ifc/step/deserializer/readonly/StepParseException.java
+++ b/IfcPlugins/src/org/bimserver/ifc/step/deserializer/readonly/StepParseException.java
@@ -1,0 +1,11 @@
+package org.bimserver.ifc.step.deserializer.readonly;
+
+import java.io.IOException;
+
+class StepParseException extends IOException {
+	private static final long serialVersionUID = 1L;
+
+	public StepParseException(String message) {
+		super(message);
+	}
+}

--- a/IfcPlugins/src/org/bimserver/ifc/step/deserializer/readonly/StepParser.java
+++ b/IfcPlugins/src/org/bimserver/ifc/step/deserializer/readonly/StepParser.java
@@ -1,0 +1,175 @@
+package org.bimserver.ifc.step.deserializer.readonly;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+
+class StepParser {
+	public static final byte POSITION_BITS = 32;
+	public static final byte DATA_BITS = 27;
+	public static final byte TYPE_BITS = 5;
+
+	public static final byte ELEMENT_ENTITY_INSTANCE = 0;
+	public static final byte ELEMENT_INSTANCE_NAME = 1;
+	public static final byte ELEMENT_LIST = 2;
+	public static final byte ELEMENT_STRING = 3;
+	public static final byte ELEMENT_INTEGER = 4;
+	public static final byte ELEMENT_REAL = 5;
+	public static final byte ELEMENT_ENUM = 6;
+
+	private InputStream in;
+
+	public StepParser(InputStream in) {
+		this.in = in;
+	}
+
+	public StepExchange parse() throws IOException {
+		ByteBuffer dataBuffer = new ByteBuffer();
+		TokenBuffer tokenBuffer = new TokenBuffer();
+		read(in, dataBuffer);
+		StepTokenizer tokenizer = new StepTokenizer(dataBuffer, tokenBuffer);
+		expectNextTokenType(tokenizer, StepTokenizer.TOKEN_BEGIN_EXCHANGE,
+				"Expected 'ISO-10303-21'");
+		expectNextTokenType(tokenizer, StepTokenizer.TOKEN_SEMICOLON,
+				"Expected ';'");
+		int headerIndex = parseHeader(tokenizer);
+		int dataIndex = parseData(tokenizer);
+		expectNextTokenType(tokenizer, StepTokenizer.TOKEN_END_EXCHANGE,
+				"Expected 'END-ISO-10303-21'");
+		expectNextTokenType(tokenizer, StepTokenizer.TOKEN_SEMICOLON,
+				"Expected ';'");
+		return new StepExchangeImpl(dataBuffer, tokenBuffer, headerIndex,
+				dataIndex);
+	}
+
+	private static void expectNextTokenType(StepTokenizer tokenizer,
+			byte tokenType, String missingMessage) throws IOException {
+		if (tokenizer.nextToken()) {
+			tokenizer.parseToken();
+			expectTokenType(tokenizer, tokenType, missingMessage);
+		} else {
+			throw new EOFException();
+		}
+	}
+
+	private static void expectTokenType(StepTokenizer tokenizer,
+			byte tokenType, String missingMessage) throws StepParseException {
+		if (tokenizer.tokenType() != tokenType) {
+			byte[] buffer = new byte[tokenizer.tokenLength()];
+			tokenizer.tokenValue(buffer);
+			throw new StepParseException("Unexpected token '"
+					+ new String(buffer) + "'. " + missingMessage);
+		}
+	}
+
+	private static void expectTokenType(StepTokenizer tokenizer, byte tokenType)
+			throws StepParseException {
+		if (tokenizer.tokenType() != tokenType) {
+			byte[] buffer = new byte[tokenizer.tokenLength()];
+			tokenizer.tokenValue(buffer);
+			throw new StepParseException("Unexpected token '"
+					+ new String(buffer) + "'");
+		}
+	}
+
+	private static int parseHeader(StepTokenizer tokenizer) throws IOException {
+		expectNextTokenType(tokenizer, StepTokenizer.TOKEN_HEADER,
+				"Expected 'HEADER'");
+		expectNextTokenType(tokenizer, StepTokenizer.TOKEN_SEMICOLON,
+				"Expected ';'");
+		int index = tokenizer.getTokenBuffer().length();
+		while (tokenizer.nextToken()) {
+			tokenizer.parseToken();
+			switch (tokenizer.tokenType()) {
+			case StepTokenizer.TOKEN_ENDSEC:
+				expectNextTokenType(tokenizer, StepTokenizer.TOKEN_SEMICOLON,
+						"Expected ';'");
+				return index;
+			default:
+				parseEntityInstance(tokenizer);
+				break;
+			}
+		}
+		return -1;
+	}
+
+	private static void parseEntityInstance(StepTokenizer tokenizer)
+			throws IOException {
+		expectTokenType(tokenizer, StepTokenizer.TOKEN_IDENTIFIER);
+		expectNextTokenType(tokenizer, StepTokenizer.TOKEN_LPAREN,
+				"Expected '('");
+		parseList(tokenizer);
+		expectNextTokenType(tokenizer, StepTokenizer.TOKEN_SEMICOLON,
+				"Expected ';'");
+	}
+
+	private static void parseList(StepTokenizer tokenizer) throws IOException {
+		while (tokenizer.nextToken()) {
+			tokenizer.parseToken();
+			switch (tokenizer.tokenType()) {
+			case StepTokenizer.TOKEN_RPAREN:
+				return;
+			case StepTokenizer.TOKEN_COMMA:
+				break;
+			default:
+				parseAttribute(tokenizer);
+				break;
+			}
+		}
+	}
+
+	private static void parseAttribute(StepTokenizer tokenizer)
+			throws IOException {
+		switch (tokenizer.tokenType()) {
+		case StepTokenizer.TOKEN_LPAREN:
+			parseList(tokenizer);
+			break;
+		default:
+			break;
+		}
+	}
+
+	private static int parseData(StepTokenizer tokenizer) throws IOException {
+		expectNextTokenType(tokenizer, StepTokenizer.TOKEN_DATA,
+				"Expected 'DATA'");
+		expectNextTokenType(tokenizer, StepTokenizer.TOKEN_SEMICOLON,
+				"Expected ';'");
+		int index = tokenizer.getTokenBuffer().length();
+		while (tokenizer.nextToken()) {
+			tokenizer.parseToken();
+			switch (tokenizer.tokenType()) {
+			case StepTokenizer.TOKEN_ENDSEC:
+				expectNextTokenType(tokenizer, StepTokenizer.TOKEN_SEMICOLON,
+						"Expected ';'");
+				return index;
+			default:
+				parseNamedEntityInstance(tokenizer);
+				break;
+			}
+		}
+		return -1;
+	}
+
+	private static void parseNamedEntityInstance(StepTokenizer tokenizer)
+			throws IOException {
+		expectTokenType(tokenizer, StepTokenizer.TOKEN_INSTANCE_NAME);
+		expectNextTokenType(tokenizer, StepTokenizer.TOKEN_EQUAL,
+				"Expected '='");
+		expectNextTokenType(tokenizer, StepTokenizer.TOKEN_IDENTIFIER,
+				"Expected identifier");
+		expectNextTokenType(tokenizer, StepTokenizer.TOKEN_LPAREN,
+				"Expected '('");
+		parseList(tokenizer);
+		expectNextTokenType(tokenizer, StepTokenizer.TOKEN_SEMICOLON,
+				"Expected ';'");
+	}
+
+	private static void read(InputStream in, ByteBuffer dataBuffer)
+			throws IOException {
+		byte[] buffer = new byte[4096];
+		int length = 0;
+		while ((length = in.read(buffer, 0, buffer.length)) > 0) {
+			dataBuffer.append(buffer, 0, length);
+		}
+	}
+}

--- a/IfcPlugins/src/org/bimserver/ifc/step/deserializer/readonly/StepStringDecoder.java
+++ b/IfcPlugins/src/org/bimserver/ifc/step/deserializer/readonly/StepStringDecoder.java
@@ -1,0 +1,165 @@
+package org.bimserver.ifc.step.deserializer.readonly;
+
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
+
+import org.apache.geronimo.mail.util.Hex;
+
+class StepStringDecoder {
+
+	private static CharsetDecoder decoder_ISO_8859_1 = Charset.forName(
+			"ISO-8859-1").newDecoder();
+	private static CharsetDecoder[] decoder_ISO_8859 = { decoder_ISO_8859_1,
+			Charset.forName("ISO-8859-2").newDecoder(),
+			Charset.forName("ISO-8859-3").newDecoder(),
+			Charset.forName("ISO-8859-4").newDecoder(),
+			Charset.forName("ISO-8859-5").newDecoder(),
+			Charset.forName("ISO-8859-6").newDecoder(),
+			Charset.forName("ISO-8859-7").newDecoder(),
+			Charset.forName("ISO-8859-8").newDecoder(),
+			Charset.forName("ISO-8859-9").newDecoder() };
+	private static CharsetDecoder decoder_UTF_16 = Charset.forName("UTF-16BE")
+			.newDecoder();
+	private static CharsetDecoder decoder_UTF_32 = Charset.forName("UTF-32")
+			.newDecoder();
+
+	public static String decode(String str) {
+		return decode(str.getBytes());
+	}
+
+	public static String decode(byte[] bytes) {
+		CharsetDecoder decoder = null;
+
+		StringBuilder sb = new StringBuilder();
+		int index = 0;
+		while (index < bytes.length) {
+
+			char c = (char) bytes[index];
+			switch (c) {
+
+			case '\'':
+
+				switch ((char) bytes[index + 1]) {
+
+				case '\'':
+					sb.append('\'');
+					index += 2;
+					break;
+
+				default:
+					throw new RuntimeException("Invalid string");
+
+				}
+
+				break;
+
+			case '\\':
+
+				switch ((char) bytes[index + 1]) {
+
+				case '\\':
+					sb.append('\\');
+					index += 2;
+					break;
+
+				case 'S':
+					if ((char) bytes[index + 2] == '\\') {
+						if (decoder == null) {
+							sb.append((char) (bytes[index + 3] + 128));
+						} else {
+							byte[] buffer = { (byte) (bytes[index + 3] + 128) };
+							try {
+								sb.append(decoder.decode(java.nio.ByteBuffer
+										.wrap(buffer)));
+							} catch (CharacterCodingException e) {
+								throw new RuntimeException(e);
+							}
+						}
+						index += 4;
+					} else {
+						index++;
+					}
+					break;
+
+				case 'P':
+					decoder = decoder_ISO_8859[bytes[index + 2] - 'A'];
+					index += 4;
+					break;
+
+				case 'X':
+					switch ((char) bytes[index + 2]) {
+
+					case '\\': {
+						byte[] hexBuffer = new byte[2];
+						System.arraycopy(bytes, index + 3, hexBuffer, 0, 2);
+						try {
+							sb.append(decoder_ISO_8859_1
+									.decode(java.nio.ByteBuffer.wrap(Hex
+											.decode(hexBuffer))));
+						} catch (CharacterCodingException e) {
+							throw new RuntimeException(e);
+						}
+						index += 5;
+					}
+						break;
+					case '2': {
+						if ((char) bytes[index + 3] != '\\') {
+							throw new RuntimeException("Expected \\");
+						}
+						byte[] hexBuffer = new byte[4];
+						int i = index + 4;
+						do {
+							System.arraycopy(bytes, i, hexBuffer, 0, 4);
+							try {
+								sb.append(decoder_UTF_16
+										.decode(java.nio.ByteBuffer.wrap(Hex
+												.decode(hexBuffer))));
+							} catch (CharacterCodingException e) {
+								throw new RuntimeException(e);
+							}
+							i += 4;
+						} while ((char) bytes[i] != '\\');
+						index = i + 4;
+					}
+						break;
+					case '4': {
+						if ((char) bytes[index + 3] != '\\') {
+							throw new RuntimeException("Expected \\");
+						}
+						byte[] hexBuffer = new byte[8];
+						int i = index + 4;
+						do {
+							System.arraycopy(bytes, i, hexBuffer, 0, 8);
+							try {
+								sb.append(decoder_UTF_32
+										.decode(java.nio.ByteBuffer.wrap(Hex
+												.decode(hexBuffer))));
+							} catch (CharacterCodingException e) {
+								throw new RuntimeException(e);
+							}
+							i += 8;
+						} while ((char) bytes[i] != '\\');
+						index = i + 4;
+					}
+						break;
+					}
+
+					break;
+
+				default:
+					throw new RuntimeException("Unknown control code");
+
+				}
+
+				break;
+			default:
+				sb.append(c);
+				index++;
+				break;
+			}
+		}
+		return sb.toString();
+	}
+
+}

--- a/IfcPlugins/src/org/bimserver/ifc/step/deserializer/readonly/StepTokenizer.java
+++ b/IfcPlugins/src/org/bimserver/ifc/step/deserializer/readonly/StepTokenizer.java
@@ -1,0 +1,422 @@
+package org.bimserver.ifc.step.deserializer.readonly;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+class StepTokenizer {
+	public static final byte POSITION_BITS = 32;
+	public static final byte LENGTH_BITS = 27;
+	public static final byte TYPE_BITS = 5;
+
+	public static final byte TOKEN_BEGIN_EXCHANGE = 0;
+	public static final byte TOKEN_END_EXCHANGE = 1;
+	public static final byte TOKEN_HEADER = 2;
+	public static final byte TOKEN_DATA = 3;
+	public static final byte TOKEN_ENDSEC = 4;
+	public static final byte TOKEN_IDENTIFIER = 5;
+	public static final byte TOKEN_ENUM = 6;
+	public static final byte TOKEN_INSTANCE_NAME = 7;
+	public static final byte TOKEN_INTEGER = 8;
+	public static final byte TOKEN_REAL= 9;
+	public static final byte TOKEN_STRING = 10;
+	public static final byte TOKEN_UNSET = 11;
+	public static final byte TOKEN_REDECLARED = 12;
+	public static final byte TOKEN_EQUAL = 13;
+	public static final byte TOKEN_LPAREN = 14;
+	public static final byte TOKEN_RPAREN = 15;
+	public static final byte TOKEN_COMMA = 16;
+	public static final byte TOKEN_SEMICOLON = 17;
+	public static final byte TOKEN_EOF = 18;
+
+	public static byte[] BEGIN_EXCHANGE = "ISO-10303-21".getBytes();
+	public static byte[] END_EXCHANGE = "END-ISO-10303-21".getBytes();
+	public static byte[] HEADER = "HEADER".getBytes();
+	public static byte[] DATA = "DATA".getBytes();
+	public static byte[] ENDSEC = "ENDSEC".getBytes();
+
+	private ByteBuffer dataBuffer;
+	private TokenBuffer tokenBuffer;
+
+	private int dataPosition;
+	private long token;
+
+	private static class ListElement {
+		public int index;
+		public int length;
+	}
+
+	private Deque<ListElement> listStack = new ArrayDeque<ListElement>();
+
+	public StepTokenizer(ByteBuffer dataBuffer, TokenBuffer tokenBuffer) {
+		this.dataBuffer = dataBuffer;
+		this.tokenBuffer = tokenBuffer;
+	}
+
+	public ByteBuffer getDataBuffer() {
+		return dataBuffer;
+	}
+
+	public TokenBuffer getTokenBuffer() {
+		return tokenBuffer;
+	}
+
+	public void parseToken() throws IOException {
+		boolean parsed = false;
+		skipWhitespace();
+		byte c = dataBuffer.byteAt(dataPosition);
+		switch (c) {
+		case '+':
+		case '-':
+			parseNumber();
+			parsed = true;
+			break;
+		case '0':
+		case '1':
+		case '2':
+		case '3':
+		case '4':
+		case '5':
+		case '6':
+		case '7':
+		case '8':
+		case '9':
+			parseNumber();
+			parsed = true;
+			break;
+		case '(':
+		{
+			ListElement elmt = new ListElement();
+			elmt.index = tokenBuffer.length();
+			elmt.length = 0;
+			listStack.push(elmt);
+
+			tokenBuffer.append((token = token(TOKEN_LPAREN, 1)));
+			parsed = true;
+			break;
+		}
+		case ')':
+		{
+			if (listStack.isEmpty()) {
+				throw new StepParseException("Unexpected character )");
+			}
+			ListElement elmt = listStack.pop();
+			if (elmt.index != tokenBuffer.length() - 1) {
+				elmt.length++;
+			}
+			tokenBuffer.set(elmt.index, token(TOKEN_LPAREN, elmt.length << 1));
+
+			tokenBuffer.append((token = token(TOKEN_RPAREN, 1)));
+			parsed = true;
+			break;
+		}
+		case ',':
+			listStack.peek().length++;
+			token = token(TOKEN_COMMA, 1);
+			parsed = true;
+			break;
+		case '\'':
+			parseString();
+			parsed = true;
+			break;
+		case '.':
+			parseEnum();
+			parsed = true;
+			break;
+		case '#':
+			parseInstanceName();
+			parsed = true;
+			break;
+		case '$':
+			tokenBuffer.append((token = token(TOKEN_UNSET, 1)));
+			parsed = true;
+			break;
+		case '*':
+			tokenBuffer.append((token = token(TOKEN_REDECLARED, 1)));
+			parsed = true;
+			break;
+		case '=':
+			tokenBuffer.append((token = token(TOKEN_EQUAL, 1)));
+			parsed = true;
+			break;
+		case ';':
+			token = token(TOKEN_SEMICOLON, 1);
+			parsed = true;
+			break;
+		case 'I':
+			parsed = parseKeyword(BEGIN_EXCHANGE, TOKEN_BEGIN_EXCHANGE);
+			break;
+		case 'E':
+			parsed = parseKeyword(ENDSEC, TOKEN_ENDSEC)
+					|| parseKeyword(END_EXCHANGE, TOKEN_END_EXCHANGE);
+			break;
+		case 'H':
+			parsed = parseKeyword(HEADER, TOKEN_HEADER);
+			break;
+		case 'D':
+			parsed = parseKeyword(DATA, TOKEN_DATA);
+			break;
+		default:
+			break;
+		}
+		if (!parsed) {
+			if (!parseIdentifier()) {
+				throw new StepParseException(String.format(
+						"Unexpected character %c", c));
+			}
+		}
+	}
+
+	private void skipWhitespace() {
+		while (true) {
+			byte c = dataBuffer.byteAt(dataPosition);
+			switch (c) {
+			case '/':
+				if (dataBuffer.byteAt(dataPosition + 1) == '*') {
+					skipComment();
+				} else {
+					return;
+				}
+				break;
+			case '\n':
+			case 13:
+			case '\t':
+			case ' ':
+				dataPosition++;
+				continue;
+			default:
+				return;
+			}
+		}
+	}
+
+	private void skipComment() {
+		dataPosition += 2;
+		while (true) {
+			byte c = dataBuffer.byteAt(dataPosition);
+			switch (c) {
+			case '*':
+				if (dataBuffer.byteAt(dataPosition + 1) == '/') {
+					dataPosition += 2;
+					return;
+				} else {
+					dataPosition++;
+				}
+				break;
+			case '/':
+				if (dataBuffer.byteAt(dataPosition + 1) == '*') {
+					skipComment();
+				} else {
+					dataPosition++;
+				}
+				break;
+			default:
+				dataPosition++;
+				break;
+			}
+		}
+		
+	}
+
+	private boolean parseKeyword(byte[] keyword, byte keywordToken) {
+		if (dataBuffer.length() < dataPosition + keyword.length) {
+			return false;
+		}
+		for (int i = 0; i < keyword.length; i++) {
+			if (keyword[i] != dataBuffer.byteAt(dataPosition + i)) {
+				return false;
+			}
+		}
+		if (dataBuffer.length() == dataPosition + keyword.length) {
+			tokenBuffer.append((token = token(keywordToken, keyword.length)));
+			return true;
+		} else {
+			byte c = dataBuffer.byteAt(dataPosition + keyword.length);
+			switch (c) {
+			case ';':
+			case '\t':
+			case '\n':
+			case ' ':
+				tokenBuffer.append((token = token(keywordToken, keyword.length)));
+				return true;
+			default:
+				return false;
+			}
+		}
+	}
+
+	private void parseInstanceName() {
+		int i = dataPosition + 1;
+		for (;; i++) {
+			if (i >= dataBuffer.length()) {
+				break;
+			}
+			byte c = dataBuffer.byteAt(i);
+			if (c < '0' || c > '9') {
+				break;
+			}
+		}
+		tokenBuffer.append((token = token(TOKEN_INSTANCE_NAME, dataPosition + 1, i
+				- dataPosition - 1)));
+	}
+
+	private void parseNumber() {
+		byte c = 0;
+		int i = dataPosition + 1;
+		for (;; i++) {
+			if (i >= dataBuffer.length()) {
+				break;
+			}
+			c = dataBuffer.byteAt(i);
+			if (c < '0' || c > '9') {
+				break;
+			}
+		}
+		if (c == '.') {
+			for (i++;; i++) {
+				if (i >= dataBuffer.length()) {
+					break;
+				}
+				c = dataBuffer.byteAt(i);
+				if (c < '0' || c > '9') {
+					break;
+				}
+			}
+			if (c == 'E') {
+				for (i++;;) {
+					if (i >= dataBuffer.length()) {
+						break;
+					}
+					c = dataBuffer.byteAt(i);
+					if (c == '-' || c == '+') {
+						i++;
+					}
+					for (;; i++) {
+						if (i >= dataBuffer.length()) {
+							break;
+						}
+						c = dataBuffer.byteAt(i);
+						if (c < '0' || c > '9') {
+							break;
+						}
+					}
+					break;
+				}
+			}
+			tokenBuffer.append((token = token(TOKEN_REAL, i - dataPosition)));
+		} else {
+			tokenBuffer.append((token = token(TOKEN_INTEGER, i - dataPosition)));
+		}
+	}
+
+	private void parseString() throws EOFException {
+		int i = dataPosition + 1;
+		for (;; i++) {
+			if (i >= dataBuffer.length()) {
+				throw new EOFException();
+			}
+			byte c = dataBuffer.byteAt(i);
+			if (c == '\'') {
+				if (dataBuffer.byteAt(i + 1) == '\'') {
+					i++;
+				} else {
+					break;
+				}
+			}
+		}
+		tokenBuffer.append((token = token(TOKEN_STRING, dataPosition + 1, i
+				- dataPosition - 1)));
+	}
+
+	private boolean parseIdentifier() {
+		byte c = dataBuffer.byteAt(dataPosition);
+		if (c >= 'A' && c <= 'Z') {
+			int i = dataPosition + 1;
+			for (;; i++) {
+				if (i >= dataBuffer.length()) {
+					break;
+				}
+				c = dataBuffer.byteAt(i);
+				if (!((c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_')) {
+					break;
+				}
+			}
+			tokenBuffer.append((token = token(TOKEN_IDENTIFIER, dataPosition, i
+					- dataPosition)));
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	private void parseEnum() throws EOFException {
+		int i = dataPosition + 1;
+		for (;; i++) {
+			if (i >= dataBuffer.length()) {
+				throw new EOFException();
+			}
+			byte c = dataBuffer.byteAt(i);
+			if (c == '.') {
+				break;
+			}
+		}
+		tokenBuffer.append((token = token(TOKEN_ENUM, dataPosition + 1, i - dataPosition
+				- 1)));
+	}
+
+	private long token(byte type, int length) {
+		return token(type, dataPosition, length);
+	}
+
+	static long token(byte type, int position, int length) {
+		return ((long) position << POSITION_BITS) | (length << TYPE_BITS)
+				| (type & ((1 << TYPE_BITS) - 1));
+	}
+
+	public byte tokenType() {
+		return tokenType(token);
+	}
+
+	public static byte tokenType(long token) {
+		return (byte) (token & ((1 << TYPE_BITS) - 1));
+	}
+
+	public int tokenPosition() {
+		return tokenPosition(token);
+	}
+
+	public static int tokenPosition(long token) {
+		return (int) (token >> POSITION_BITS);
+	}
+
+	public int tokenLength() {
+		return tokenLength(token);
+	}
+
+	public static int tokenLength(long token) {
+		return (int) ((token >> TYPE_BITS) & ((1 << LENGTH_BITS) - 1));
+	}
+
+	public void tokenValue(byte[] buffer) {
+		dataBuffer.bytesAt(buffer, tokenPosition(), tokenLength());
+	}
+
+	public boolean nextToken() {
+		if (tokenBuffer.length() > 0) {
+			switch (tokenType()) {
+			case TOKEN_INSTANCE_NAME:
+				dataPosition += tokenLength() + 1;
+				break;
+			case TOKEN_ENUM:
+			case TOKEN_STRING:
+				dataPosition += tokenLength() + 2;
+				break;
+			default:
+				dataPosition += tokenLength();
+				break;
+			}
+		}
+		return dataPosition < dataBuffer.length();
+	}
+}

--- a/IfcPlugins/src/org/bimserver/ifc/step/deserializer/readonly/TokenBuffer.java
+++ b/IfcPlugins/src/org/bimserver/ifc/step/deserializer/readonly/TokenBuffer.java
@@ -1,0 +1,85 @@
+package org.bimserver.ifc.step.deserializer.readonly;
+
+class TokenBuffer {
+	private TokenBufferPage first = new TokenBufferPage(1 << 20);
+	private TokenBufferPage readPage = first;
+	private TokenBufferPage writePage = first;
+	private int readPageIndex = 0;
+	private int writePageIndex = 0;
+	private int length;
+
+	public void append(long token) {
+		int pageIndex = length >> 20;
+		TokenBufferPage page = writePage;
+		if (writePageIndex != pageIndex) {
+			int i = writePageIndex;
+			if (writePageIndex < pageIndex) {
+				page = first;
+				i = 0;
+			}
+			for (; i < pageIndex; i++) {
+				if (page.next == null) {
+					page.next = new TokenBufferPage(1 << 20);
+				}
+				page = page.next;
+			}
+			writePage = page;
+			writePageIndex = pageIndex;
+		}
+
+		page.buffer[page.position] = token;
+		page.position++;
+		length++;
+	}
+
+	public long tokenAt(int index) {
+		if (index >= length) {
+			throw new IndexOutOfBoundsException();
+		}
+		int pageIndex = index >> 20;
+		TokenBufferPage page = readPage;
+		if (readPageIndex != pageIndex) {
+			int i = readPageIndex;
+			if (pageIndex < readPageIndex) {
+				page = first;
+				i = 0;
+			}
+			for (; i < pageIndex; i++) {
+				page = page.next;
+			}
+			readPage = page;
+			readPageIndex = pageIndex;
+		}
+		return page.buffer[index & 0xFFFFF];
+	}
+
+	public int length() {
+		return length;
+	}
+
+	public void set(int index, long token) {
+		if (index >= length) {
+			throw new IndexOutOfBoundsException();
+		}
+
+		int pageIndex = index >> 20;
+		TokenBufferPage page = writePage;
+		if (writePageIndex != pageIndex) {
+			int i = writePageIndex;
+			if (pageIndex < writePageIndex) {
+				page = first;
+				i = 0;
+			}
+			for (; i < pageIndex; i++) {
+				if (page.next == null) {
+					page.next = new TokenBufferPage(1 << 20);
+				}
+				page = page.next;
+			}
+			writePage = page;
+			writePageIndex = pageIndex;
+		}
+
+		page.buffer[index & 0xFFFFF] = token;
+	}
+}

--- a/IfcPlugins/src/org/bimserver/ifc/step/deserializer/readonly/TokenBufferPage.java
+++ b/IfcPlugins/src/org/bimserver/ifc/step/deserializer/readonly/TokenBufferPage.java
@@ -1,0 +1,11 @@
+package org.bimserver.ifc.step.deserializer.readonly;
+
+class TokenBufferPage {
+	long[] buffer;
+	int position;
+	public TokenBufferPage next;
+
+	public TokenBufferPage(int length) {
+		buffer = new long[length];
+	}
+}

--- a/IfcPlugins/src/org/bimserver/ifc/step/serializer/IfcStepSerializer.java
+++ b/IfcPlugins/src/org/bimserver/ifc/step/serializer/IfcStepSerializer.java
@@ -104,7 +104,7 @@ public class IfcStepSerializer extends IfcSerializer {
 					throw new SerializerException(e);
 			}
 			setMode(Mode.BODY);
-			iterator = model.getValues().iterator();
+			iterator = model.iterator();
 			out.flush();
 			return true;
 		} else if (getMode() == Mode.BODY) {


### PR DESCRIPTION
Plug-in parses STEP data into a new read-only IfcModelInterface implementation. Data
is stored in-memory and is converted to EMF objects on demand.
